### PR TITLE
Define manifest_version in skin.json

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -94,5 +94,6 @@
 	"ResourceFileModulePaths": {
 		"localBasePath": "",
 		"remoteSkinPath": "ModernSkylight"
-	}
+	},
+	"manifest_version": 1
 }


### PR DESCRIPTION
MediaWiki 1.29+ complains when running maintenance scripts if `manifest_version` isn't defined here.