### PR TITLE
Set "manifest_version" to 1

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -94,5 +94,6 @@
 	"ResourceFileModulePaths": {
 		"localBasePath": "",
 		"remoteSkinPath": "ModernSkylight"
-	}
+	},
+	"manifest_version": 1
 }


### PR DESCRIPTION
It's deprecated now to not manifest_version have set in extension.json

"Use of Modern Skylight's extension.json or skin.json does not have manifest_version was deprecated in MediaWiki 1.29. [Called from ExtensionRegistry::loadFromQueue in /srv/mediawiki/w/includes/registration/ExtensionRegistry.php at line 161]"